### PR TITLE
EDGECLOUD-1978: IOS QosPosition incorrectly parses QosPositionKpiReply stream

### DIFF
--- a/IOSMatchingEngineSDK/Example/Tests/ConnectionTests.swift
+++ b/IOSMatchingEngineSDK/Example/Tests/ConnectionTests.swift
@@ -177,8 +177,8 @@ class ConnectionTests: XCTestCase {
         var socket: SocketIOClient!
         var manager: SocketManager!
         
-        let host = "frankfurt-main.tdg.mobiledgex.net"
-        let port = UInt16(3001)
+        let host = "ponggame-tcp.frankfurt-main.tdg.mobiledgex.net"
+        let port = UInt16(3000)
         var connected = false
         
         let replyPromise = matchingEngine.getWebsocketConnection(host: host, port: port)

--- a/IOSMatchingEngineSDK/Example/Tests/Tests.swift
+++ b/IOSMatchingEngineSDK/Example/Tests/Tests.swift
@@ -289,7 +289,7 @@ class Tests: XCTestCase {
         let QosPositionKpiReply = MobiledgeXiOSLibrary.MatchingEngine.QosPositionKpiReply.self
         let status = promiseValue.status
         
-        XCTAssert(status != MobiledgeXiOSLibrary.MatchingEngine.ReplyStatus.RS_SUCCESS, "QoSPosition failed: \(status)")
+        XCTAssert(status == MobiledgeXiOSLibrary.MatchingEngine.ReplyStatus.RS_SUCCESS, "QoSPosition failed: \(status)")
         
         XCTAssertNil(replyPromise.error, "QoSPosition Error is set: \(String(describing: replyPromise.error))")
     }


### PR DESCRIPTION
1. The URLSession data task now uses a delegate instead of a completion handler to handle incoming data. This allows for more flexible stream handling.
- Delegate appends the data each time the URLSession data task receives data
- Once the URLSession task completes, the delegate decodes the data into QosPositionKpiReplyStream (which is {"result": QosPositionKpiReply} )

(Note: One strange issue is the "positionid" in the QosPositionKpiResult objects returned have to be decoded as Strings instead of Int64. Not really sure why)
