### PR TITLE
EDGECLOUD-2377: Fix RegisterAndFindCloudlet

### DIFF
--- a/IOSMatchingEngineSDK/Example/MatchingEngine/ViewController.swift
+++ b/IOSMatchingEngineSDK/Example/MatchingEngine/ViewController.swift
@@ -26,7 +26,6 @@ import os.log
 
 import DropDown
 import MobiledgeXiOSLibrary
-
 // quick and dirty global scope
 
 var theMap: GMSMapView?     //   used by sample.client
@@ -169,12 +168,7 @@ class ViewController: UIViewController, GMSMapViewDelegate, UIAdaptivePresentati
         let registerClientRequest = matchingEngine.createRegisterClientRequest(orgName: orgName,
                                                                    appName: appName,
                                                                    appVers: appVers,
-                                                                   carrierName: carrierName,
-                                                                   authToken: authToken,
-                                                                   uniqueIDType: uniqueIDType,
-                                                                   uniqueID: uniqueID,
-                                                                   cellID: cellID,
-                                                                   tags: tags)
+                                                                   carrierName: carrierName)
         matchingEngine.registerClient(host: host,
                           port: port,
                           request: registerClientRequest)
@@ -212,7 +206,7 @@ class ViewController: UIViewController, GMSMapViewDelegate, UIAdaptivePresentati
             SKToast.show(withMessage: "Client registered")
             
             let loc = retrieveLocation()
-            let request = self!.matchingEngine.createGetAppInstListRequest(carrierName: self!.carrierName, gpsLocation: loc, cellID: self!.cellID, tags: nil)
+            let request = self!.matchingEngine.createGetAppInstListRequest(gpsLocation: loc, carrierName: self!.carrierName)
             self!.matchingEngine.getAppInstList(host: self!.host, port: self!.port, request: request)
                 .then { appInstList in
                     // Ick. Refactor, to just "Toast" the SDK usage status in UI at each promises chain stage:
@@ -471,12 +465,7 @@ class ViewController: UIViewController, GMSMapViewDelegate, UIAdaptivePresentati
                 let registerClientRequest = self!.matchingEngine.createRegisterClientRequest(orgName: self!.orgName,
                                                                                  appName: self!.appName,
                                                                                  appVers: self!.appVers,
-                                                                                 carrierName: self!.carrierName,
-                                                                                 authToken: self!.authToken,
-                                                                                 uniqueIDType: self!.uniqueIDType,
-                                                                                 uniqueID: self!.uniqueID,
-                                                                                 cellID: self!.cellID,
-                                                                                 tags: self!.tags)
+                                                                                 carrierName: self!.carrierName)
                 if (self!.demo) {  //used for demo purposes
                     self!.registerPromise = self!.matchingEngine.registerClient(
                         host: self!.demoHost, port: self!.port, request: registerClientRequest)
@@ -508,7 +497,7 @@ class ViewController: UIViewController, GMSMapViewDelegate, UIAdaptivePresentati
             case 1:
                 let loc = retrieveLocation()
                 
-                let appInstListRequest = self!.matchingEngine.createGetAppInstListRequest(carrierName: self!.carrierName, gpsLocation: loc, cellID: self!.cellID, tags: self!.tags)
+                let appInstListRequest = self!.matchingEngine.createGetAppInstListRequest(gpsLocation: loc, carrierName: self!.carrierName)
                 if (self!.demo) {
                     self!.matchingEngine.getAppInstList(host: self!.demoHost, port: self!.port, request: appInstListRequest)
                     .then { appInstListReply in
@@ -550,7 +539,7 @@ class ViewController: UIViewController, GMSMapViewDelegate, UIAdaptivePresentati
                     let loc = retrieveLocation()
                     
                     let verifyLocRequest = self!.matchingEngine.createVerifyLocationRequest(
-                        carrierName: self!.carrierName, gpsLocation: loc, cellID: self!.cellID, tags: self!.tags)
+                        gpsLocation: loc, carrierName: self!.carrierName)
                     if (self!.demo) {
                         self!.verifyLocationPromise = self!.matchingEngine.verifyLocation(host: self!.demoHost, port: self!.port, request: verifyLocRequest)
                         .then { verifyLocationReply in
@@ -591,9 +580,7 @@ class ViewController: UIViewController, GMSMapViewDelegate, UIAdaptivePresentati
                 let loc = retrieveLocation()
                 // FIXME: register client is a promise.
 
-                let findCloudletRequest = self!.matchingEngine.createFindCloudletRequest(carrierName: self!.carrierName,
-                                                                             gpsLocation: loc, orgName: self!.orgName,
-                                                                             appName: self!.appName, appVers: self!.appVers, cellID: self!.cellID, tags: self!.tags)
+                let findCloudletRequest = self!.matchingEngine.createFindCloudletRequest(gpsLocation: loc, carrierName: self!.carrierName)
                 if (self!.demo) {
                     self!.matchingEngine.findCloudlet(host: self!.demoHost, port: self!.port, request: findCloudletRequest)
                     .then { findCloudletReply in
@@ -628,7 +615,7 @@ class ViewController: UIViewController, GMSMapViewDelegate, UIAdaptivePresentati
                                                       totalDistanceKm: 200,
                                                       increment: 1)
                 
-                let getQoSPositionRequest = self!.matchingEngine.createQosKPIRequest(requests: positions, lteCategory: nil, bandSelection: nil, cellID: self!.cellID, tags: self!.tags)
+                let getQoSPositionRequest = self!.matchingEngine.createQosKPIRequest(requests: positions)
                 if (self!.demo) {
                     self!.matchingEngine.getQosKPIPosition(host: self!.demoHost, port: self!.port, request: getQoSPositionRequest)
                     .then { getQoSPositionReply in

--- a/IOSMatchingEngineSDK/Example/Tests/ConnectionTests.swift
+++ b/IOSMatchingEngineSDK/Example/Tests/ConnectionTests.swift
@@ -274,7 +274,7 @@ class ConnectionTests: XCTestCase {
     func testGetConnectionWorkflow() {
         let loc = MobiledgeXiOSLibrary.MatchingEngine.Loc(latitude:  37.459609, longitude: -122.149349)
         
-        let replyPromise = matchingEngine.registerAndFindCloudlet(orgName: "MobiledgeX", appName: "HttpEcho", appVers: "20191204", carrierName: nil, authToken: nil, gpsLocation: loc, uniqueIDType: nil, uniqueID: nil, cellID: nil, tags: nil)
+        let replyPromise = matchingEngine.registerAndFindCloudlet(orgName: "MobiledgeX", appName: "HttpEcho", appVers: "20191204", carrierName: "TDG", gpsLocation: loc)
             
         .then { findCloudletReply -> Promise<MobiledgeXiOSLibrary.Socket> in
             // Get Dictionary: key -> internal port, value -> AppPort Dictionary
@@ -369,7 +369,7 @@ class ConnectionTests: XCTestCase {
     func testTimeout() {
         let loc = MobiledgeXiOSLibrary.MatchingEngine.Loc(latitude:  37.459609, longitude: -122.149349)
         
-        let replyPromise = matchingEngine.registerAndFindCloudlet(orgName: "MobiledgeX", appName: "HttpEcho", appVers: "20191204", carrierName: "TDG", authToken: nil, gpsLocation: loc, uniqueIDType: nil, uniqueID: nil, cellID: nil, tags: nil)
+        let replyPromise = matchingEngine.registerAndFindCloudlet(orgName: "MobiledgeX", appName: "HttpEcho", appVers: "20191204", carrierName: "TDG", gpsLocation: loc)
             
         .then { findCloudletReply -> Promise<NWConnection> in
             // Get Dictionary: key -> internal port, value -> AppPort Dictionary

--- a/IOSMatchingEngineSDK/Example/Tests/Tests.swift
+++ b/IOSMatchingEngineSDK/Example/Tests/Tests.swift
@@ -93,7 +93,7 @@ class Tests: XCTestCase {
     }
     
     func testRegisterClient() {
-        let request = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
+        let request = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName)
 
         // Host goes to mexdemo, not tdg. tdg is the registered name for the app.
         var replyPromise: Promise<MobiledgeXiOSLibrary.MatchingEngine.RegisterClientReply>!
@@ -120,19 +120,13 @@ class Tests: XCTestCase {
     func testFindCloudlet() {
         let loc = MobiledgeXiOSLibrary.MatchingEngine.Loc(latitude:  37.459609, longitude: -122.149349)
                 
-        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
+        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName)
         
         var replyPromise: Promise<MobiledgeXiOSLibrary.MatchingEngine.FindCloudletReply>!
             replyPromise = matchingEngine.registerClient(host: dmeStageHost, port: dmePort, request: regRequest)
                 .then { reply in
                     self.matchingEngine.findCloudlet(host: self.dmeStageHost, port: self.dmePort, request: self.matchingEngine.createFindCloudletRequest(
-                                                        carrierName: self.carrierName,
-                                                        gpsLocation: loc,
-                                                        orgName: nil,
-                                                        appName: nil,
-                                                        appVers: nil,
-                                                        cellID: self.cellID,
-                                                        tags: self.tags))
+                        gpsLocation: loc, carrierName: self.carrierName))
                 }.catch { error in
                     XCTAssert(false, "FindCloudlet encountered error: \(error)")
             }
@@ -153,17 +147,15 @@ class Tests: XCTestCase {
     func testVerifyLocation() {
         let loc = MobiledgeXiOSLibrary.MatchingEngine.Loc(latitude:  37.459609, longitude: -122.149349)
 
-        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
+        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName)
         
         var replyPromise: Promise<MobiledgeXiOSLibrary.MatchingEngine.VerifyLocationReply>!
 
         replyPromise = matchingEngine.registerClient(host: dmeStageHost, port: dmePort, request: regRequest)
                 .then { reply in
                     self.matchingEngine.verifyLocation(host: self.dmeStageHost, port: self.dmePort, request: self.matchingEngine.createVerifyLocationRequest(
-                                                        carrierName: nil,
                                                         gpsLocation: loc,
-                                                        cellID: self.cellID,
-                                                        tags: self.tags))
+                                                        carrierName: self.carrierName))
                 }.catch { error in
                     XCTAssert(false, "VerifyLocationReply hit an error: \(error).")
             }
@@ -188,7 +180,7 @@ class Tests: XCTestCase {
     func testAppInstList() {
         let loc = MobiledgeXiOSLibrary.MatchingEngine.Loc(latitude:  37.459609, longitude: -122.149349)
         
-        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
+        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName)
         
         // Host goes to mexdemo, not tdg. tdg is the registered name for the app.
         var replyPromise: Promise<MobiledgeXiOSLibrary.MatchingEngine.AppInstListReply>!
@@ -196,10 +188,7 @@ class Tests: XCTestCase {
             replyPromise = matchingEngine.registerClient(host: dmeStageHost, port: dmePort, request: regRequest)
                 .then { reply in
                     self.matchingEngine.getAppInstList(host: self.dmeStageHost, port: self.dmePort, request: self.matchingEngine.createGetAppInstListRequest(
-                                                        carrierName: self.carrierName,
-                                                        gpsLocation: loc,
-                                                        cellID: self.cellID,
-                                                        tags: self.tags))
+                        gpsLocation: loc, carrierName: self.carrierName))
                     }.catch { error in
                         XCTAssert(false, "AppInstList hit an error: \(error).")
                     }
@@ -264,18 +253,14 @@ class Tests: XCTestCase {
                                               totalDistanceKm: 200,
                                               increment: 1)
         
-        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
+        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName)
         
         var replyPromise: Promise<MobiledgeXiOSLibrary.MatchingEngine.QosPositionKpiReply>!
         
             replyPromise = matchingEngine.registerClient(host: dmeStageHost, port: dmePort, request: regRequest)
                 .then { reply in
                     self.matchingEngine.getQosKPIPosition(host: self.dmeStageHost, port: self.dmePort, request: self.matchingEngine.createQosKPIRequest(
-                                                            requests: positions,
-                                                            lteCategory: nil,
-                                                            bandSelection: nil,
-                                                            cellID: self.cellID,
-                                                            tags: self.tags))
+                                                            requests: positions))
                 } .catch { error in
                     XCTAssert(false, "Did not succeed get QOS Position KPI. Error: \(error)")
             }
@@ -296,14 +281,14 @@ class Tests: XCTestCase {
     }
     
     func testGetLocation() {
-        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
+        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName)
         
         var replyPromise: Promise<MobiledgeXiOSLibrary.MatchingEngine.GetLocationReply>!
         
             replyPromise = matchingEngine.registerClient(host: dmeStageHost, port: dmePort, request: regRequest)
                 .then { reply in
                     self.matchingEngine.getLocation(host: self.dmeStageHost, port: self.dmePort, request: self.matchingEngine.createGetLocationRequest(
-                        carrierName: nil, cellID: self.cellID, tags: self.tags))
+                        carrierName: self.carrierName))
                 } .catch { error in
                     XCTAssert(false, "Did not succeed getLocation. Error: \(error)")
             }
@@ -322,13 +307,13 @@ class Tests: XCTestCase {
     }
     
     func testAddUsertoGroup() {
-        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
+        let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName)
         
         var replyPromise: Promise<MobiledgeXiOSLibrary.MatchingEngine.DynamicLocGroupReply>!
 
             replyPromise = matchingEngine.registerClient(host: dmeStageHost, port: dmePort, request: regRequest)
                 .then { reply in
-                    self.matchingEngine.addUserToGroup(host: self.dmeStageHost, port: self.dmePort, request: self.matchingEngine.createDynamicLocGroupRequest(lg_id: nil, commType: nil, userData: nil, cellID: self.cellID, tags: self.tags))
+                    self.matchingEngine.addUserToGroup(host: self.dmeStageHost, port: self.dmePort, request: self.matchingEngine.createDynamicLocGroupRequest())
                 } .catch { error in
                     XCTAssert(false, "Did not succeed addUserToGroup. Error: \(error)")
             }
@@ -348,7 +333,7 @@ class Tests: XCTestCase {
     
     func testRegisterAndFindCloudlet() {
         let loc = MobiledgeXiOSLibrary.MatchingEngine.Loc(latitude: 37.459609, longitude: -122.149349)
-        let replyPromise = matchingEngine.registerAndFindCloudlet(host: dmeStageHost, port: dmePort, orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, gpsLocation: loc, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
+        let replyPromise = matchingEngine.registerAndFindCloudlet(host: dmeStageHost, port: dmePort, orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, gpsLocation: loc)
         .catch { error in
             XCTAssert(false, "Error is \(error)")
         }

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/AddUserToGroup.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/AddUserToGroup.swift
@@ -56,7 +56,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     ///   - user_data
     ///
     /// - Returns: API Dictionary/json
-    public func createDynamicLocGroupRequest(lg_id: UInt64?, commType: DynamicLocGroupRequest.DlgCommType?, userData: String?, cellID: uint?, tags: [Tag]?) -> DynamicLocGroupRequest {
+    public func createDynamicLocGroupRequest(lg_id: UInt64? = nil, commType: DynamicLocGroupRequest.DlgCommType? = nil, userData: String? = nil, cellID: uint? = nil, tags: [Tag]? = nil) -> DynamicLocGroupRequest {
         
         return DynamicLocGroupRequest(
             ver: 1,

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/AppInstList.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/AppInstList.swift
@@ -71,7 +71,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     ///   - gpslocation: A dictionary with at least longitude and latitude key values.
     ///
     /// - Returns: API Dictionary/json
-    public func createGetAppInstListRequest(carrierName: String?, gpsLocation: Loc, cellID: uint?, tags: [Tag]?) -> AppInstListRequest {
+    public func createGetAppInstListRequest(gpsLocation: Loc, carrierName: String?,  cellID: uint? = nil, tags: [Tag]? = nil) -> AppInstListRequest {
         
         return AppInstListRequest(
             ver: 1,

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/FindCloudlet.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/FindCloudlet.swift
@@ -67,8 +67,8 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     /// - Returns: API  Dictionary/json
     
     // Carrier name can change depending on cell tower.
-    public func createFindCloudletRequest(carrierName: String?, gpsLocation: Loc,
-                                          orgName: String?, appName: String?, appVers: String?, cellID: uint?, tags: [Tag]?)
+    public func createFindCloudletRequest(gpsLocation: Loc, carrierName: String?,
+                                          orgName: String? = nil, appName: String? = nil, appVers: String? = nil, cellID: uint? = nil, tags: [Tag]? = nil)
         -> FindCloudletRequest {
             
         return FindCloudletRequest(

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetLocation.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetLocation.swift
@@ -55,7 +55,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     /// - Parameters:
     ///   - carrierName: carrierName description
     /// - Returns: API  Dictionary/json
-    public func createGetLocationRequest(carrierName: String?, cellID: uint?, tags: [Tag]?) -> GetLocationRequest {
+    public func createGetLocationRequest(carrierName: String?, cellID: uint? = nil, tags: [Tag]? = nil) -> GetLocationRequest {
         
         return GetLocationRequest(
             ver: 1,

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/QoSPositionKpi.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/QoSPositionKpi.swift
@@ -88,7 +88,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     /// - Parameters:
     ///   -requests: QosPositions (Dict: id -> gps location)
     /// - Returns: API  Dictionary/json
-    public func createQosKPIRequest(requests: [QosPosition], lteCategory: Int32?, bandSelection: BandSelection?, cellID: uint?, tags: [Tag]?) -> QosPositionRequest {
+    public func createQosKPIRequest(requests: [QosPosition], lteCategory: Int32? = nil, bandSelection: BandSelection? = nil, cellID: uint? = nil, tags: [Tag]? = nil) -> QosPositionRequest {
         
         return QosPositionRequest(
             ver: 1,

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterAndFindCloudlet.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterAndFindCloudlet.swift
@@ -22,7 +22,7 @@ import Promises
 extension MobiledgeXiOSLibrary.MatchingEngine
 {
 
-    public func registerAndFindCloudlet(orgName: String, appName: String?, appVers: String?, carrierName: String?, authToken: String?, gpsLocation: Loc, uniqueIDType: IDTypes?, uniqueID: String?, cellID: UInt32?, tags: [Tag]?) -> Promise<FindCloudletReply> {
+    public func registerAndFindCloudlet(orgName: String, appName: String?, appVers: String?, carrierName: String?, gpsLocation: Loc, authToken: String? = nil, uniqueIDType: IDTypes? = nil, uniqueID: String? = nil, cellID: UInt32? = nil, tags: [Tag]? = nil) -> Promise<FindCloudletReply> {
                 
         let registerRequest = self.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
         
@@ -36,13 +36,13 @@ extension MobiledgeXiOSLibrary.MatchingEngine
                 return promiseInputs
             }
             
-            let findCloudletRequest = self.createFindCloudletRequest(carrierName: carrierName, gpsLocation: gpsLocation, orgName: nil, appName: nil, appVers: nil, cellID: cellID, tags: tags)
+            let findCloudletRequest = self.createFindCloudletRequest(gpsLocation: gpsLocation, carrierName: carrierName, cellID: cellID, tags: tags)
             
             return self.findCloudlet(request: findCloudletRequest)
         }
     }
     
-    public func registerAndFindCloudlet(host: String, port: UInt16, orgName: String, appName: String?, appVers: String?, carrierName: String?, authToken: String?, gpsLocation: Loc, uniqueIDType: IDTypes?, uniqueID: String?, cellID: UInt32?, tags: [Tag]?) -> Promise<FindCloudletReply> {
+    public func registerAndFindCloudlet(host: String, port: UInt16, orgName: String, appName: String?, appVers: String?, carrierName: String?, gpsLocation: Loc, authToken: String? = nil, uniqueIDType: IDTypes? = nil, uniqueID: String? = nil, cellID: UInt32? = nil, tags: [Tag]? = nil) -> Promise<FindCloudletReply> {
         
         let registerRequest = self.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, carrierName: carrierName, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
         
@@ -56,7 +56,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine
                     return promiseInputs
                 }
                 
-                let findCloudletRequest = self.createFindCloudletRequest(carrierName: carrierName, gpsLocation: gpsLocation, orgName: nil, appName: nil, appVers: nil, cellID: cellID, tags: tags)
+                let findCloudletRequest = self.createFindCloudletRequest(gpsLocation: gpsLocation, carrierName: carrierName, cellID: cellID, tags: tags)
                 
                 return self.findCloudlet(host: host, port: port, request: findCloudletRequest)
         }

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterClient.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterClient.swift
@@ -73,8 +73,12 @@ extension MobiledgeXiOSLibrary.MatchingEngine
     ///   - carrierName: Name of the mobile carrier.
     ///   - authToken: An optional opaque string to authenticate the client.
     /// - Returns: API Dictionary/json
-    public func createRegisterClientRequest(orgName: String, appName: String?, appVers: String?, carrierName: String?, authToken: String?, uniqueIDType: IDTypes?, uniqueID: String?, cellID: UInt32?, tags: [Tag]?)
+    public func createRegisterClientRequest(orgName: String, appName: String?, appVers: String?, carrierName: String?, authToken: String? = nil, uniqueIDType: IDTypes? = nil, uniqueID: String? = nil, cellID: UInt32? = nil, tags: [Tag]? = nil)
         -> RegisterClientRequest { // Dictionary/json
+            
+        if carrierName != nil {
+            state.carrierName = carrierName
+        }
             
         return RegisterClientRequest(
             ver: 1,

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/VerifyLocation.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/VerifyLocation.swift
@@ -77,7 +77,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
             return nil
         }
 
-        let verifyLocRequest = createVerifyLocationRequest(carrierName: getCarrierName(), gpsLocation: gpsLocation, cellID: cellID, tags: tags)
+            let verifyLocRequest = createVerifyLocationRequest(gpsLocation: gpsLocation, carrierName: getCarrierName(), cellID: cellID, tags: tags)
         return self.verifyLocation(request: verifyLocRequest)
     }
     
@@ -89,8 +89,8 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     ///   - verifyloctoken: <#verifyloctoken description#>
     ///
     /// - Returns: API json/Dictionary
-    public func createVerifyLocationRequest(carrierName: String?,
-                                            gpsLocation: Loc, cellID: uint?, tags: [Tag]?)
+    public func createVerifyLocationRequest(gpsLocation: Loc, carrierName: String?,
+                                            cellID: uint? = nil, tags: [Tag]? = nil)
         -> VerifyLocationRequest {
             
         return VerifyLocationRequest(
@@ -191,14 +191,14 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         }
     }
     
-    private func tokenizeRequest(carrierName: String, verifyLocationToken: String, gpsLocation: Loc, cellID: uint?, tags: [Tag]?)
+    private func tokenizeRequest(carrierName: String, verifyLocationToken: String, gpsLocation: Loc, cellID: uint? = nil, tags: [Tag]? = nil)
         throws -> VerifyLocationRequest {
             
         if (verifyLocationToken.count == 0) {
             throw InvalidTokenServerTokenError.invalidToken
         }
         
-        var verifyLocationRequest = self.createVerifyLocationRequest(carrierName: carrierName, gpsLocation: gpsLocation, cellID: cellID, tags: tags)
+            var verifyLocationRequest = self.createVerifyLocationRequest(gpsLocation: gpsLocation, carrierName: carrierName, cellID: cellID, tags: tags)
         verifyLocationRequest.verify_loc_token = verifyLocationToken
             
         return verifyLocationRequest


### PR DESCRIPTION
- Add override for registerAndFindCloudlet with host and port params. 

- FindCloudlet fails if given appName, appVers, or orgName