### PR TITLE
EDGECLOUD-2418: Swift MatchingEngine Exceptions are unclear

### DIFF
--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineErrors.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineErrors.swift
@@ -58,13 +58,15 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     }
     
     public enum UrlSessionError: Error {
+        case transportError(errorMessage: String)
         case invalidHttpUrlResponse
-        case badStatusCode(status: Int)
+        case badStatusCode(status: Int, errorMessage: String)
         
         public var errorDescription: String? {
             switch self {
+            case .transportError(let errorMessage): return "Transport error: \(errorMessage)"
             case .invalidHttpUrlResponse: return "Unable to convert URLResponse to HTTPURLResponse"
-            case .badStatusCode(let status): return "Bad HTTP Status Code: \(status)"
+            case .badStatusCode(let status, let errorMessage): return "Bad HTTP Status Code: \(status). Error message is: \(errorMessage)"
             }
         }
     }

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineProto.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineProto.swift
@@ -61,6 +61,12 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         case L_PROTO_HTTP = "L_PROTO_HTTP"
     }
     
+    // Object used in timestamp field of Loc
+    public struct Timestamp: Codable {
+        public var seconds: Int64?
+        public var nanos: Int32?
+    }
+    
     // Object used and returned in gps_location field of serveral API requests and replies
     public struct Loc: Codable {
         
@@ -76,12 +82,6 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         public var altitude: Double?
         public var course: Double?
         public var speed: Double?
-        public var timestamp: Timestamp?
-        
-        // Object used in timestamp field of Loc
-        public struct Timestamp: Codable {
-            public var seconds: Int64?
-            public var nanos: Int32?
-        }
+        public var Timestamp: Timestamp?
     }
 }

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineUtil.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineUtil.swift
@@ -24,19 +24,11 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
 
     public func getAppName() -> String
     {
-        if state.appName == nil || state.appName == ""
-        {
-            throw MatchingEngineError.missingAppName
-        }
         return state.appName
     }
     
     public func getAppVersion() -> String
     {
-        if state.appVersion == nil || state.appVersion == ""
-        {
-            throw MatchingEngineError.missingAppVersion
-        }
         return state.appVersion
     }
     

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngineState/MatchingEngineState.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngineState/MatchingEngineState.swift
@@ -48,33 +48,26 @@ extension MobiledgeXiOSLibrary {
         
         private var useWifiOnly: Bool = false
         
-        init()
-        {
+        init() {
             print(Bundle.main.object)
             networkInfo = CTTelephonyNetworkInfo()
             device = UIDevice.init()
         }
         
-        public var appName: String
-        {
-            get
-            {
+        public var appName: String {
+            get {
                 return Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? ""
             }
         }
         
-        public var appVersion: String
-        {
-            get
-            {
+        public var appVersion: String {
+            get {
                 return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
             }
         }
         
-        var uuid: String?
-        {
-            get
-            {
+        var uuid: String? {
+            get {
                 guard let uuid = device.identifierForVendor else {
                     return nil
                 }
@@ -99,39 +92,32 @@ extension MobiledgeXiOSLibrary {
             return useWifiOnly
         }
         
-        func setSessionCookie(sessionCookie: String?)
-        {
+        func setSessionCookie(sessionCookie: String?) {
             self.sessionCookie = sessionCookie
         }
         
-        func getSessionCookie() -> String?
-        {
+        func getSessionCookie() -> String? {
             return self.sessionCookie
         }
         
-        func setTokenServerUri(tokenServerUri: String?)
-        {
+        func setTokenServerUri(tokenServerUri: String?) {
             self.tokenServerUri = tokenServerUri
         }
         
-        func getTokenServerUri() -> String?
-        {
+        func getTokenServerUri() -> String? {
             return self.tokenServerUri
         }
         
-        func setTokenServerToken(tokenServerToken: String?)
-        {
+        func setTokenServerToken(tokenServerToken: String?) {
             self.tokenServerToken = tokenServerToken
         }
         
-        func getTokenServerToken() -> String?
-        {
+        func getTokenServerToken() -> String? {
             return self.tokenServerToken
         }
         
         // Returns Array with MCC in zeroth index and MNC in first index
-        func getMCCMNC() throws -> [String]
-        {
+        func getMCCMNC() throws -> [String] {
             if #available(iOS 12.0, *) {
                 ctCarriers = networkInfo.serviceSubscriberCellularProviders
             } else {


### PR DESCRIPTION
This came up when trying to determine correct behavior for when CreateRegisterClient() is unable to generate appName and appVers. Normally, if you RegisterClient with a missing or empty string appName/appVers, DME will send a nice message that says "AppName cannot be empty" or "AppVersion cannot be empty". I was never able to see these messages in Swift, so it was hard to tell what went wrong with the request (network error, or request error, etc.). 

So, I added String descriptions to a couple errors, converted the data returned by URLSession to a string and added that to Error message. Now this is logged:`Error: badStatusCode(status: 400, errorMessage: "{\n \"code\": 3,\n \"message\": \"AppName cannot be empty\",\n \"details\": [\n ]\n}")`.

We don't need extra exceptions in createRegisterClientRequest and all errors can be caught and understood in the RegisterClient promise chain.