### PR TITLE
fix casting issues, public MatchingEngineState

### DIFF
--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetConnection/GetConnection.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetConnection/GetConnection.swift
@@ -379,29 +379,24 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     
     private func constructHost(findCloudletReply: FindCloudletReply, appPort: AppPort) throws -> String {
         // Convert fqdn_prefix and fqdn to string
-        guard let fqdnPrefix = appPort.fqdn_prefix as? String else {
-            os_log("Unable to cast fqdn prefix as String", log: OSLog.default, type: .debug)
-            throw GetConnectionError.variableConversionError(message: "Unable to cast fqdn prefix as String")
-        }
-        guard let fqdn = findCloudletReply.fqdn as? String else {
-            os_log("Unable to cast fqdn as String", log: OSLog.default, type: .debug)
-            throw GetConnectionError.variableConversionError(message: "Unable to cast fqdn as String")
+        var fqdnPrefix = appPort.fqdn_prefix
+        if fqdnPrefix == nil {
+            fqdnPrefix = ""
         }
         
-        let host = fqdnPrefix + fqdn
+        let fqdn = findCloudletReply.fqdn
+        
+        let host = fqdnPrefix! + fqdn
         return host
     }
     
     private func getPort(appPort: AppPort, desiredPort: Int) throws -> UInt16 {
         var port: UInt16
         
-        guard let publicPort = appPort.public_port as? UInt16 else {
-            os_log("Unable to cast public port as String", log: OSLog.default, type: .debug)
-            throw GetConnectionError.variableConversionError(message: "Unable to cast public port as String")
-        }
+        let publicPort = appPort.public_port
         // If desired port is -1, then default to public port
         if desiredPort == -1 {
-            port = publicPort
+            port = UInt16(truncatingIfNeeded: publicPort)
         } else {
             port = UInt16(desiredPort)
         }
@@ -418,34 +413,34 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     
     private func constructHTTPUri(findCloudletReply: FindCloudletReply, appPort: AppPort, desiredPort: Int) throws -> String {
         // Convert fqdn_prefix and fqdn to string
-        guard let fqdnPrefix = appPort.fqdn_prefix as? String else {
-            os_log("Unable to cast fqdn prefix as String", log: OSLog.default, type: .debug)
-            throw GetConnectionError.variableConversionError(message: "Unable to cast fqdn prefix as String")
-        }
-        guard let fqdn = findCloudletReply.fqdn as? String else {
-            os_log("Unable to cast fqdn as String", log: OSLog.default, type: .debug)
-            throw GetConnectionError.variableConversionError(message: "Unable to cast fqdn as String")
-        }
-        guard let pathPrefix = appPort.path_prefix as? String else {
-            os_log("Unable to cast path prefix as String", log: OSLog.default, type: .debug)
-            throw GetConnectionError.variableConversionError(message: "Unable to case path prefix as String")
+        var fqdnPrefix = appPort.fqdn_prefix
+        if fqdnPrefix == nil {
+            fqdnPrefix = ""
         }
         
-        let host = fqdnPrefix + fqdn
+        let fqdn = findCloudletReply.fqdn
+        
+        var pathPrefix = appPort.path_prefix
+        if pathPrefix == nil {
+            pathPrefix = ""
+        }
+        
+        let host = fqdnPrefix! + fqdn
         let port = try getPort(appPort: appPort, desiredPort: desiredPort)
-        let uri = host + ":" + String(describing: port) + pathPrefix
+        let uri = host + ":" + String(describing: port) + pathPrefix!
         return uri
     }
     
     
     private func isInPortRange(appPort: AppPort, port: UInt16) throws -> Bool
     {
-        guard let publicPort = appPort.public_port as? UInt16 else {
-            throw GetConnectionError.variableConversionError(message: "Unable to cast public_port to Int")
+        let publicPort = UInt16(truncatingIfNeeded: appPort.public_port)
+        
+        var u16EndPort = appPort.end_port
+        if u16EndPort == nil {
+            u16EndPort = 0
         }
-        guard let endPort = appPort.end_port as? UInt16 else {
-            throw GetConnectionError.variableConversionError(message: "Unable to cast end_port to Int")
-        }
+        let endPort = UInt16(truncatingIfNeeded: u16EndPort!)
         // Checks if a range exists -> if not, check if specified port equals public_port
         if (endPort == 0 || endPort < publicPort) {
             return port == publicPort

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngine.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngine.swift
@@ -52,7 +52,8 @@ extension MobiledgeXiOSLibrary {
             "Charsets": "utf-8",
         ]
         
-        var state: MatchingEngineState
+        public var state: MatchingEngineState
+        
         var urlConfiguration: URLSessionConfiguration?
         var urlSession: URLSession?
 

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineProto.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineProto.swift
@@ -82,6 +82,6 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         public var altitude: Double?
         public var course: Double?
         public var speed: Double?
-        public var Timestamp: Timestamp?
+        public var timestamp: Timestamp?
     }
 }

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineUtil.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineUtil.swift
@@ -34,7 +34,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     
     // TODO: Other types are valid.
     public func validateGpsLocation(gpsLocation: Loc) throws -> Bool {
-        if let longitude = gpsLocation.longitude as? CLLocationDegrees {
+        if let longitude = gpsLocation.longitude {
             if longitude < -180 as CLLocationDegrees || longitude > 180 as CLLocationDegrees
             {
                 throw MatchingEngineError.invalidGPSLongitude
@@ -43,7 +43,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
             throw MatchingEngineError.invalidGPSLongitude
         }
         
-        if let latitude = gpsLocation.latitude as? CLLocationDegrees {
+        if let latitude = gpsLocation.latitude {
             if latitude < -90 as CLLocationDegrees || latitude > 90 as CLLocationDegrees
             {
                 throw MatchingEngineError.invalidGPSLatitude

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterClient.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterClient.swift
@@ -133,10 +133,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine
         // Return a promise chain:
         return self.postRequest(uri: urlStr, request: request, type: RegisterClientReply.self).then { reply in
             
-            guard let registerClientReply = reply as? RegisterClientReply else {
-                promiseInputs.reject(MatchingEngineError.registerFailed)
-                return
-            }
+            let registerClientReply = reply
 
             self.state.setSessionCookie(sessionCookie: registerClientReply.session_cookie)
             os_log("saved sessioncookie", log: OSLog.default, type: .debug)


### PR DESCRIPTION
1) Fixed some unresolved casting issues since the change from Dictionaries to Codable objects
2) Made the MatchingEngineState variable public, so that developers can useWifiOnly (@ah1053 so we can fallback to wifi if we catch an exception in ARShooter)

I'm also having some strange behavior with Promises, where sometimes waitForPromises doesn't catch that the promise has been fulfilled. (Similar issue with all() function in ARShooter). Might have to switch to PromiseKit library instead of Google promises in the future. 