### PR TITLE
EDGECLOUD-2712: Swift: Mirror C# SDK FindCloudlet: Proximity Mode default.

### DIFF
--- a/IOSMatchingEngineSDK/Example/Tests/Tests.swift
+++ b/IOSMatchingEngineSDK/Example/Tests/Tests.swift
@@ -102,7 +102,7 @@ class Tests: XCTestCase {
     
     // Test the FindCloudlet DME API
     @available(iOS 13.0, *)
-    func testFindCloudletAPI() {
+    func testFindCloudletProximity() {
         let loc = MobiledgeXiOSLibrary.MatchingEngine.Loc(latitude:  37.459609, longitude: -122.149349)
                 
         let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers)
@@ -131,7 +131,7 @@ class Tests: XCTestCase {
     
     // Test FindCloudlet that call AppInstList and NetTest to find cloudlet with lowest latency
     @available(iOS 13.0, *)
-    func testFindCloudlet() {
+    func testFindCloudletPerformance() {
         let loc = MobiledgeXiOSLibrary.MatchingEngine.Loc(latitude:  37.459609, longitude: -122.149349)
                 
         let regRequest = matchingEngine.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers)

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterAndFindCloudlet.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterAndFindCloudlet.swift
@@ -23,7 +23,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine
 {
 
     @available(iOS 13.0, *)
-    public func registerAndFindCloudlet(orgName: String, gpsLocation: Loc, appName: String? = nil, appVers: String? = nil, carrierName: String? = "", authToken: String? = nil, uniqueIDType: IDTypes? = nil, uniqueID: String? = nil, cellID: UInt32? = nil, tags: [Tag]? = nil) -> Promise<FindCloudletReply> {
+    public func registerAndFindCloudlet(orgName: String, gpsLocation: Loc, appName: String? = nil, appVers: String? = nil, carrierName: String? = "", authToken: String? = nil, uniqueIDType: IDTypes? = nil, uniqueID: String? = nil, cellID: UInt32? = nil, tags: [Tag]? = nil, mode: FindCloudletMode = FindCloudletMode.PROXIMITY) -> Promise<FindCloudletReply> {
                 
         let registerRequest = self.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
         
@@ -39,12 +39,12 @@ extension MobiledgeXiOSLibrary.MatchingEngine
             
             let findCloudletRequest = self.createFindCloudletRequest(gpsLocation: gpsLocation, carrierName: carrierName, cellID: cellID, tags: tags)
             
-            return self.findCloudlet(request: findCloudletRequest)
+            return self.findCloudlet(request: findCloudletRequest, mode: mode)
         }
     }
     
     @available(iOS 13.0, *)
-    public func registerAndFindCloudlet(host: String, port: UInt16, orgName: String, gpsLocation: Loc, appName: String? = nil, appVers: String? = nil, carrierName: String? = "", authToken: String? = nil, uniqueIDType: IDTypes? = nil, uniqueID: String? = nil, cellID: UInt32? = nil, tags: [Tag]? = nil) -> Promise<FindCloudletReply> {
+    public func registerAndFindCloudlet(host: String, port: UInt16, orgName: String, gpsLocation: Loc, appName: String? = nil, appVers: String? = nil, carrierName: String? = "", authToken: String? = nil, uniqueIDType: IDTypes? = nil, uniqueID: String? = nil, cellID: UInt32? = nil, tags: [Tag]? = nil, mode: FindCloudletMode = FindCloudletMode.PROXIMITY) -> Promise<FindCloudletReply> {
         
         let registerRequest = self.createRegisterClientRequest(orgName: orgName, appName: appName, appVers: appVers, authToken: authToken, uniqueIDType: uniqueIDType, uniqueID: uniqueID, cellID: cellID, tags: tags)
         
@@ -60,7 +60,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine
                 
                 let findCloudletRequest = self.createFindCloudletRequest(gpsLocation: gpsLocation, carrierName: carrierName, cellID: cellID, tags: tags)
                 
-                return self.findCloudlet(host: host, port: port, request: findCloudletRequest)
+                return self.findCloudlet(host: host, port: port, request: findCloudletRequest, mode: mode)
         }
     }
 }


### PR DESCRIPTION
Two Public FindCloudlet functions that default to proximity mode:
1. findCloudlet(request: FindCloudletRequest, mode: FindCloudletMode = FindCloudletMode.Proximity)
2. findCloudlet(host: String, port: UInt16, request: FindCloudletRequest, mode: FindCloudletMode = FindCloudletMode.Proximity)

Two Private FindCloudlet[Mode] functions:
1. findCloudletProximity: standard DME API
2. findCloudletPerformance: findCloudletProximity, getappinst, nettest

registerAndFindCloudlet also defaults to Proximity mode