### PR TITLE
EDGECLOUD-2715: Swift carriername should default/fallback to "" instead of "wifi"

### DIFF
--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngine.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngine.swift
@@ -42,7 +42,7 @@ extension MobiledgeXiOSLibrary {
         public enum DMEConstants {
             public static let baseDmeHost: String = "dme.mobiledgex.net"
             public static let dmeRestPort: UInt16 = 38001
-            public static let fallbackCarrierName: String = "wifi"
+            public static let fallbackCarrierName: String = ""
             public static let wifiAlias: String = "wifi"
         }
         


### PR DESCRIPTION
If getMccMnc fails, GetCarrierName will return ""