### PR TITLE
EDGECLOUD-2836: Make sure Wifi/Cellular logic is correct GetCarrierName()

### DIFF
--- a/IOSMatchingEngineSDK/Example/MatchingEngine/ViewController.swift
+++ b/IOSMatchingEngineSDK/Example/MatchingEngine/ViewController.swift
@@ -719,7 +719,7 @@ class ViewController: UIViewController, GMSMapViewDelegate, UIAdaptivePresentati
             
             var hostName: String!
             do {
-                hostName = try self.matchingEngine.generateDmeHost(carrierName: cn).replacingOccurrences(of: "dme", with: "locsim")
+                hostName = try self.matchingEngine.generateDmeHost().replacingOccurrences(of: "dme", with: "locsim")
             } catch {
                 Swift.print("Error: \(error.localizedDescription)")
             }

--- a/IOSMatchingEngineSDK/Example/Tests/Tests.swift
+++ b/IOSMatchingEngineSDK/Example/Tests/Tests.swift
@@ -49,7 +49,7 @@ class Tests: XCTestCase {
         // Put setup code here. This method is called before the invocation of each test method in the class.
         
         matchingEngine = MobiledgeXiOSLibrary.MatchingEngine()
-        matchingEngine.state.setUseWifiOnly(enabled: true) // for simulator tests and phones without SIM
+        // matchingEngine.state.setUseWifiOnly(enabled: true) // for simulator tests and phones without SIM
         
         if TEST {
             appName =  "MobiledgeX SDK Demo"
@@ -110,7 +110,7 @@ class Tests: XCTestCase {
         var replyPromise: Promise<MobiledgeXiOSLibrary.MatchingEngine.FindCloudletReply>!
             replyPromise = matchingEngine.registerClient(host: dmeHost, port: dmePort, request: regRequest)
                 .then { reply in
-                    self.matchingEngine.findCloudletAPI(host: self.dmeHost, port: self.dmePort, request: self.matchingEngine.createFindCloudletRequest(
+                    self.matchingEngine.findCloudlet(host: self.dmeHost, port: self.dmePort, request: self.matchingEngine.createFindCloudletRequest(
                         gpsLocation: loc, carrierName: self.carrierName))
                 }.catch { error in
                     XCTAssert(false, "FindCloudlet encountered error: \(error)")

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/AddUserToGroup.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/AddUserToGroup.swift
@@ -83,12 +83,10 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     public func addUserToGroup (request: DynamicLocGroupRequest) -> Promise<DynamicLocGroupReply>
     {
         let promiseInputs: Promise<DynamicLocGroupReply> = Promise<DynamicLocGroupReply>.pending()
-        
-        let carrierName = state.carrierName
-        
+                
         var host: String
         do {
-            host = try generateDmeHost(carrierName: carrierName)
+            host = try generateDmeHost()
         } catch {
             promiseInputs.reject(error)
             return promiseInputs

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/AppInstList.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/AppInstList.swift
@@ -77,7 +77,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         return AppInstListRequest(
             ver: 1,
             session_cookie: state.getSessionCookie() ?? "",
-            carrier_name: carrierName ?? state.carrierName ?? getCarrierName(),
+            carrier_name: carrierName ?? getCarrierName(),
             gps_location: gpsLocation,
             cell_id: cellID,
             tags: tags)
@@ -92,12 +92,10 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     
     public func getAppInstList(request: AppInstListRequest) -> Promise<AppInstListReply> {
         let promiseInputs: Promise<AppInstListReply> = Promise<AppInstListReply>.pending()
-        
-        let carrierName = state.carrierName
-        
+                
         var host: String
         do {
-            host = try generateDmeHost(carrierName: carrierName)
+            host = try generateDmeHost()
         } catch {
             promiseInputs.reject(error)
             return promiseInputs

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/FindCloudlet.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/FindCloudlet.swift
@@ -76,7 +76,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         return FindCloudletRequest(
             ver: 1,
             session_cookie: state.getSessionCookie() ?? "",
-            carrier_name: carrierName ?? state.carrierName ?? getCarrierName(),
+            carrier_name: carrierName ?? getCarrierName(),
             gps_location: gpsLocation,
             cell_id: cellID,
             tags: tags)
@@ -98,12 +98,10 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     @available(iOS 13.0, *)
     public func findCloudlet(request: FindCloudletRequest, mode: FindCloudletMode = FindCloudletMode.PROXIMITY) -> Promise<FindCloudletReply> {
         let promiseInputs: Promise<FindCloudletReply> = Promise<FindCloudletReply>.pending()
-
-        let carrierName = state.carrierName
         
         var host: String
         do {
-            host = try generateDmeHost(carrierName: carrierName)
+            host = try generateDmeHost()
         } catch {
             promiseInputs.reject(error)
             return promiseInputs

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetLocation.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetLocation.swift
@@ -60,7 +60,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         return GetLocationRequest(
             ver: 1,
             session_cookie: state.getSessionCookie() ?? "",
-            carrier_name: carrierName ?? state.carrierName ?? getCarrierName(),
+            carrier_name: carrierName ?? getCarrierName(),
             cell_id: cellID,
             tags: tags)
     }
@@ -82,10 +82,9 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         os_log("getLocation", log: OSLog.default, type: .debug)
         let promiseInputs: Promise<GetLocationReply> = Promise<GetLocationReply>.pending()
         
-        let carrierName = state.carrierName
         var host: String
         do {
-            host = try generateDmeHost(carrierName: carrierName)
+            host = try generateDmeHost()
         } catch {
             promiseInputs.reject(error)
             return promiseInputs

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineErrors.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineErrors.swift
@@ -48,6 +48,9 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         case getQosPositionFailed
         case getAppInstListFailed
         case addUserToGroupFailed
+        
+        case wifiIsNotConnected
+        case cellularIsNotConnected
     }
     
     public enum InvalidTokenServerTokenError: Error  {

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/QoSPositionKpi.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/QoSPositionKpi.swift
@@ -183,12 +183,10 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     {
         os_log("getQosKPIPosition", log: OSLog.default, type: .debug)
         let promiseInputs: Promise<QosPositionKpiReply> = Promise<QosPositionKpiReply>.pending()
-        
-        let carrierName = state.carrierName
-        
+                
         var host: String
         do {
-            host = try generateDmeHost(carrierName: carrierName)
+            host = try generateDmeHost()
         } catch {
             promiseInputs.reject(error)
             return promiseInputs

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterClient.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterClient.swift
@@ -99,10 +99,9 @@ extension MobiledgeXiOSLibrary.MatchingEngine
         
         let promiseInputs: Promise<RegisterClientReply> = Promise<RegisterClientReply>.pending()
         
-        let carrierName = state.carrierName
         var host: String
         do {
-            host = try generateDmeHost(carrierName: carrierName)
+            host = try generateDmeHost()
         } catch {
             promiseInputs.reject(error)
             return promiseInputs

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/VerifyLocation.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/VerifyLocation.swift
@@ -96,7 +96,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         return VerifyLocationRequest(
             ver: 1,
             session_cookie: self.state.getSessionCookie() ?? "",
-            carrier_name: carrierName ?? state.carrierName ?? getCarrierName(),
+            carrier_name: carrierName ?? getCarrierName(),
             gps_location: gpsLocation,
             verify_loc_token: "",
             cell_id: cellID,
@@ -207,15 +207,9 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     public func verifyLocation(request: VerifyLocationRequest) -> Promise<VerifyLocationReply> {
         let promiseInputs: Promise<VerifyLocationReply> = Promise<VerifyLocationReply>.pending()
         
-        guard let carrierName = state.carrierName else {
-            os_log("MatchingEngine is unable to retrieve a carrierName to create a network request.", log: OSLog.default, type: .debug)
-            promiseInputs.reject(MatchingEngineError.missingCarrierName)
-            return promiseInputs
-        }
-        
         var host: String
         do {
-            host = try generateDmeHost(carrierName: carrierName)
+            host = try generateDmeHost()
         } catch {
             promiseInputs.reject(error)
             return promiseInputs

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MobiledgeXiOSLibrary.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MobiledgeXiOSLibrary.swift
@@ -32,6 +32,7 @@ public enum MobiledgeXiOSLibrary {
         case missingMNC
         case missingCellularProviderInfo
         case outdatedIOS
+        case invalidMCCMNC(mcc: String, mnc: String)
         
         public var errorDescription: String? {
             switch self {
@@ -40,6 +41,7 @@ public enum MobiledgeXiOSLibrary {
             case .missingMNC: return "Unable to get Mobile Network Code"
             case .missingCellularProviderInfo: return "Unable to find Subscriber Cellular Provider Info"
             case .outdatedIOS: return "iOS is outdated. Requires 12.0+"
+            case .invalidMCCMNC(let mcc, let mnc): return "Mcc \(mcc) and mnc \(mnc) combination are not valid"
             }
         }
     }

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/NetworkInterface/NetworkInterface.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/NetworkInterface/NetworkInterface.swift
@@ -68,6 +68,18 @@ extension MobiledgeXiOSLibrary {
             return false
         }
         
+        // Returns true if an ip address is assigned to the wifi interface
+        public static func hasWifi() -> Bool {
+            let ipaddr = getIPAddress(netInterfaceType: WIFI)
+            return ipaddr != nil && ipaddr!.count > 0
+        }
+        
+        // Returns true if an ip address is assigned to the cellular interface
+        public static func hasCellular() -> Bool {
+            let ipaddr = getIPAddress(netInterfaceType: CELLULAR)
+            return ipaddr != nil && ipaddr!.count > 0
+        }
+        
         // Gets the client IP Address on the interface specified
         // TODO: check for multiple cellular ip addresses (multiple SIM subscriptions possible)
         public static func getIPAddress(netInterfaceType: String?) -> String?


### PR DESCRIPTION
1. getCarrierName returns empty string if useWifiOnly or if getMccMnc fails.

2. generateDmeHost returns mcc-mnc.dme.mobiledgex.net as long as getMccMnc returns successfully. Otherwise it returns wifi.dme.mobiledgex.net

3. Got rid of carrierName in MatchingEngineState

4. Got rid of carrierName parameter in generateDmeHost since it wasn't being used

5. Added hasCellular and hasWifi functions that check if those interfaces have an ip address assigned