### PR TITLE
EDGECLOUD-2647: Expose CreateURI/ GetHost + GetPort

### DIFF
--- a/IOSMatchingEngineSDK/Example/Tests/ConnectionTests.swift
+++ b/IOSMatchingEngineSDK/Example/Tests/ConnectionTests.swift
@@ -177,11 +177,16 @@ class ConnectionTests: XCTestCase {
         var socket: SocketIOClient!
         var manager: SocketManager!
         
-        let host = "ponggame-tcp.frankfurt-main.tdg.mobiledgex.net"
-        let port = UInt16(3000)
+        // SocketIO server
+        let uri = "ws://arshooter-cluster.berlin-main.tdg.mobiledgex.net:3838"
+        guard let url = URL(string: uri) else {
+            XCTAssert(false, "Unable to create url")
+            return
+        }
+        
         var connected = false
         
-        let replyPromise = matchingEngine.getWebsocketConnection(host: host, port: port)
+        let replyPromise = matchingEngine.getWebsocketConnection(url: url)
             
         .then { m in
             manager = m
@@ -196,8 +201,8 @@ class ConnectionTests: XCTestCase {
             print("Did not succeed WebsocketConnection. Error: \(error)")
         }
         
-        XCTAssert(waitForPromises(timeout: 5))
-        guard let promiseValue = replyPromise.value else {
+        XCTAssert(waitForPromises(timeout: 10))
+        guard let _ = replyPromise.value else {
             XCTAssert(false, "GetWebsocketConnection did not return a value.")
             return
         }
@@ -389,7 +394,9 @@ class ConnectionTests: XCTestCase {
                 throw TestError.runtimeError("No app ports with specified internal port")
             }
             
-            return self.matchingEngine.getTCPTLSConnection(findCloudletReply: findCloudletReply, appPort: appPort, desiredPort: 3001, timeout: 100)
+            var appPortTls = appPort
+            appPortTls.tls = true
+            return self.matchingEngine.getTCPTLSConnection(findCloudletReply: findCloudletReply, appPort: appPortTls, desiredPort: 3001, timeout: 100)
         }.then { connection in
             XCTAssert(false, "Should have timed out")
         }.catch { error in

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetConnection/GetConnectionHelper.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetConnection/GetConnectionHelper.swift
@@ -107,17 +107,20 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     }
     
     // Returns SocketIOClient promise
-    func getWebsocketConnection(host: String, port: UInt16) -> Promise<SocketManager>
+    func getWebsocketConnection(url: URL) -> Promise<SocketManager>
     {
         let promise = Promise<SocketManager>(on: .global(qos: .background)) { fulfill, reject in
+            guard let host = url.host else {
+                reject(GetConnectionError.incorrectURLSyntax)
+                return
+            }
             // DNS Lookup
             do {
                 try self.verifyDmeHost(host: host)
             } catch {
                 reject(error)
             }
-            let url = "ws://\(host):\(port)/"
-            let manager = SocketManager(socketURL: URL(string: url)!)
+            let manager = SocketManager(socketURL: url)
             fulfill(manager)
         }
         return promise

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetConnection/GetPorts.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetConnection/GetPorts.swift
@@ -18,18 +18,6 @@
 
 extension MobiledgeXiOSLibrary.MatchingEngine {
     
-    // Returns the server side fqdn from findCloudletReply with specified port (fqdn prefix based on port)
-    public func getAppFqdn(findCloudletReply: FindCloudletReply, port: UInt16) -> String?
-    {
-        let appFqdn = findCloudletReply.fqdn
-        let baseFqdn = appFqdn
-        // get fqdn prefix from port dictionary
-        guard let fqdnPrefix = state.portToPathPrefixDict[port] else {
-            return baseFqdn
-        }
-        return fqdnPrefix + baseFqdn
-    }
-    
     // Returns dictionary: key -> internal port, value -> AppPort
     public func getAppPortsByProtocol(findCloudletReply: FindCloudletReply, proto: LProto) throws -> [UInt16: AppPort]?
     {

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetConnection/GetTLSConnectionHelper.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/GetConnection/GetTLSConnectionHelper.swift
@@ -94,24 +94,6 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         return promise
     }
     
-    // Returns SocketIOClient promise
-    func getSecureWebsocketConnection(host: String, port: UInt16) -> Promise<SocketManager>
-    {
-        let promise = Promise<SocketManager>(on: .global(qos: .background)) { fulfill, reject in
-            
-            // DNS Lookup
-            do {
-                try self.verifyDmeHost(host: host)
-            } catch {
-                reject(error)
-            }
-            let url = "wss://\(host):\(port)/"
-            let manager = SocketManager(socketURL: URL(string: url)!)
-            fulfill(manager)
-        }
-        return promise
-    }
-    
     @available(iOS 13.0, *)
     private func setUpStateHandler(connection: NWConnection, semaphore: DispatchSemaphore) {
         connection.stateUpdateHandler = { state in


### PR DESCRIPTION
- getHost, getPort, and createUrl public functions (moved to GetConnectionUtil.swift). Logic should be the same as C#.
- getWebsocketConnection now takes URL parameter instead of host and port
- Remove getAppFqdn 
- Remove getSecureWebsocketConnection from GetConnectionHelper.swift (tls check and wss protocol done in getSecureWebsocketConnection in GetConnection.swift)