### PR TITLE
EDGECLOUD-2987: IOS SDK: If in roaming mode, use global DME and FindCloudlet Performance Mode.

### DIFF
--- a/IOSMatchingEngineSDK/Example/Tests/Tests.swift
+++ b/IOSMatchingEngineSDK/Example/Tests/Tests.swift
@@ -391,35 +391,39 @@ class Tests: XCTestCase {
     }
     
     func testLocationServices() {
-        MobiledgeXiOSLibrary.MobiledgeXLocation.startLocationServices()
-        
-        let countryPromise = MobiledgeXiOSLibrary.MobiledgeXLocation.getLastISOCountryCode()
-        .catch { error in
-                XCTAssert(false, "Error in isRoaming test \(error)")
+        let startLocationPromise = MobiledgeXiOSLibrary.MobiledgeXLocation.startLocationServices()
+        .then { success in
+            let country = MobiledgeXiOSLibrary.MobiledgeXLocation.getLastISOCountryCode()
+            print("country code is \(country)")
+            print("lastLocation is \(MobiledgeXiOSLibrary.MobiledgeXLocation.getLastLocation())")
+        }.catch { error in
+            XCTAssert(false, "Error in location services test \(error)")
         }
+        
         XCTAssert(waitForPromises(timeout: 5))
-        guard let country = countryPromise.value else {
-            XCTAssert(false, "GetLastLocationCountry did not return a value.")
+        guard let successStartLocation = startLocationPromise.value else {
+            XCTAssert(false, "TestLocationServices did not return a value.")
             return
         }
-        print("country code is \(country)")
-        print("lastLocation is \(MobiledgeXiOSLibrary.MobiledgeXLocation.getLastLocation())")
+        
+        XCTAssert(successStartLocation)
         MobiledgeXiOSLibrary.MobiledgeXLocation.stopLocationServices()
     }
     
     func testIsRoaming() {
-        MobiledgeXiOSLibrary.MobiledgeXLocation.startLocationServices()
-
-        let roamingPromise = MobiledgeXiOSLibrary.NetworkInterface.isRoaming()
-            .catch { error in
-                XCTAssert(false, "Error in isRoaming test \(error)")
+        let roamingPromise = MobiledgeXiOSLibrary.MobiledgeXLocation.startLocationServices()
+        .then { success -> Bool in
+            let roaming = try MobiledgeXiOSLibrary.NetworkInterface.isRoaming()
+            return roaming
+        }.catch { error in
+            XCTAssert(false, "Error in isRoaming test \(error)")
         }
+            
         XCTAssert(waitForPromises(timeout: 5))
         guard let isRoaming = roamingPromise.value else {
             XCTAssert(false, "isRoaming did not return a value.")
             return
         }
-        print("isRoaming is \(isRoaming)")
         XCTAssert(isRoaming)
         MobiledgeXiOSLibrary.MobiledgeXLocation.stopLocationServices()
     }

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineUtil.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngineUtil.swift
@@ -63,6 +63,15 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
         }
         
         do {
+            let roaming = try MobiledgeXiOSLibrary.NetworkInterface.isRoaming()
+            if roaming {
+                return DMEConstants.fallbackCarrierName
+            }
+        } catch {
+            os_log("Unable to determine if device is roaming. Will continue finding current carrier's information.", log: OSLog.default, type: .debug)
+        }
+        
+        do {
             mccMnc = try MobiledgeXiOSLibrary.CarrierInfo.getMCCMNC()
         } catch {
             return DMEConstants.fallbackCarrierName
@@ -84,6 +93,15 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
             } else {
                 throw MatchingEngineError.wifiIsNotConnected
             }
+        }
+        
+        do {
+            let roaming = try MobiledgeXiOSLibrary.NetworkInterface.isRoaming()
+            if roaming {
+                return generateFallbackDmeHost(carrierName: DMEConstants.wifiAlias)
+            }
+        } catch {
+            os_log("Unable to determine if device is roaming. Will continue to find DME host based on current carrier's information.", log: OSLog.default, type: .debug)
         }
         
         do {


### PR DESCRIPTION
1. If Roaming, getCarrierName returns ""
2. If Roaming, generateDmeHostName returns "wifi.dme.mobiledgex.net"
3. MobiledgeXLocation.getLastISOCountryCode() (which is used in isRoaming to compare the device location country code with the carrier network country code) now returns String instead of Promise<String>
- Originally this function returned Promise<String>. The conversion from gpslocation to ISO country code requires async code and originally I was only converting when someone called getLastISOCountryCode.
- Now, as soon as there is a location update, I convert the gps location to an ISO country code and store that information in a class variable. Therefore, anytime somebody calls getLastISOCountryCode now, it just returns that class variable
4. MobiledgeXLocation.startLocationServices() now returns Promise<Bool> because of changes in 3). I want an iso country code to stored before handing control back to the developer. That way if they call IsRoaming immediately after starting location services, there will be a country code available to check. Also this allows developers to see and handle when LocationService starts incorrectly


TODO: Objective C plugin for Unity