### PR TITLE
EDGECLOUD-3159: Log which DME is being used

### DIFF
--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngine.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/MatchingEngine.swift
@@ -67,6 +67,7 @@ extension MobiledgeXiOSLibrary {
         // API Rest calls use this function to post "requests" (ie. RegisterClient() posts RegisterClientRequest)
         public func postRequest<Request: Encodable, Reply: Decodable>(uri: String, request: Request, type: Reply.Type) -> Promise<Reply> {
             
+            os_log("Posting http request. URI is: %@", log: OSLog.default, type: .debug, uri)
             return Promise<Reply>(on: self.state.executionQueue) {
                 fulfill, reject in
                 //create URLRequest object

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterClient.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/RegisterClient.swift
@@ -126,7 +126,6 @@ extension MobiledgeXiOSLibrary.MatchingEngine
         os_log("registerClient", log: OSLog.default, type: .debug)
         
         let baseuri = generateBaseUri(host: host, port: port)
-        os_log("BaseURI: %@", log: OSLog.default, type: .debug, baseuri)
         let urlStr = baseuri + APIPaths.registerAPI
         
         // Return a promise chain:

--- a/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/VerifyLocation.swift
+++ b/IOSMatchingEngineSDK/MobiledgeXiOSLibrary/Classes/MatchingEngine/VerifyLocation.swift
@@ -99,7 +99,7 @@ extension MobiledgeXiOSLibrary.MatchingEngine {
     private func getTokenPost(uri: String) // Dictionary/json
         -> Promise<[String: AnyObject]> {
             
-        os_log("uri: %@ request\n", log: OSLog.default, type: .debug, uri)
+        os_log("getToken Post request. uri: %@ request\n", log: OSLog.default, type: .debug, uri)
         
         return Promise<[String: AnyObject]>(on: self.state.executionQueue) { fulfill, reject in
             //Create URLRequest object


### PR DESCRIPTION
- Added a log message printing the uri before posting http request. 
- Deleted extra log (1 point of control in postRequest)